### PR TITLE
Move date-format to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/davidparsson/junit-report-builder",
   "devDependencies": {
-    "date-format": "0.0.2",
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",
@@ -36,6 +35,7 @@
   "dependencies": {
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",
-    "xmlbuilder": "^2.6.2"
+    "xmlbuilder": "^2.6.2",
+    "date-format": "0.0.2"
   }
 }


### PR DESCRIPTION
`date-format` is a runtime dependency, as it's used in https://github.com/davidparsson/junit-report-builder/blob/master/src/test_suite.js#L2.