### PR TITLE
Enable emoji encoding

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -17,7 +17,7 @@ JUnitReportBuilder.prototype.writeTo = function (reportPath) {
 };
 
 JUnitReportBuilder.prototype.build = function () {
-  var xmlTree = xmlBuilder.create('testsuites', { encoding: 'UTF-8' });
+  var xmlTree = xmlBuilder.create('testsuites', { encoding: 'UTF-8', allowSurrogateChars: true });
   _.forEach(this._testSuitesAndCases, function (suiteOrCase) {
     suiteOrCase.build(xmlTree);
   });


### PR DESCRIPTION
I encountered the same issue as https://github.com/oozcitak/xmlbuilder-js/issues/98.  This fixes it so that the builder doesn't explode when running into emoji.