### PR TITLE
Adding ability to include attachment in system-err

### DIFF
--- a/spec/e2e_spec.coffee
+++ b/spec/e2e_spec.coffee
@@ -166,6 +166,20 @@ describe 'JUnit Report builder', ->
       '    </testcase>\n' +
       '  </testsuite>')
 
+  it 'should print the reported attachment to system-err', ->
+    builder.testSuite().testCase()
+      .standardError("This was written to stderr!")
+      .errorAttachment("absolute/path/to/attachment")
+
+    expect(builder.build()).toBe reportWith(
+      '  <testsuite tests="1" failures="0" errors="0" skipped="0">\n' +
+      '    <testcase>\n' +
+      '      <system-err>\n' +
+      '        <![CDATA[This was written to stderr!]]>\n' +
+      '        [[ATTACHMENT|absolute/path/to/attachment]]\n' +
+      '      </system-err>\n' +
+      '    </testcase>\n' +
+      '  </testsuite>')
 
   it 'should output test suites and test cases in the order reported', ->
     builder.testCase().name(1)

--- a/spec/test_case_spec.coffee
+++ b/spec/test_case_spec.coffee
@@ -11,7 +11,7 @@ describe 'Test Case builder', ->
   systemErrElement = null
 
   createElementMock = (elementName) ->
-    jasmine.createSpyObj(elementName, ['ele', 'cdata', 'att'])
+    jasmine.createSpyObj(elementName, ['ele', 'cdata', 'att', 'txt'])
 
   beforeEach ->
     testCase = new TestCase()
@@ -33,6 +33,9 @@ describe 'Test Case builder', ->
         when 'system-out' then return systemOutElement
         when 'system-err' then return systemErrElement
 
+    systemErrElement.cdata.and.callFake (stdError) ->
+      switch stdError
+        when 'Error with screenshot' then return systemErrElement
 
   it 'should build a testcase element without attributes by default', ->
     testCase.build parentElement
@@ -190,6 +193,16 @@ describe 'Test Case builder', ->
 
       expect(systemErrElement.cdata).not.toHaveBeenCalledWith('Standard error')
       expect(systemErrElement.cdata).toHaveBeenCalledWith('Second stderr')
+
+    it 'should add an attachment to system-err', ->
+      testCase.standardError('Error with screenshot')
+      testCase.errorAttachment('absolute/path/to/attachment')
+
+      testCase.build parentElement
+
+      expect(testCaseElement.ele).toHaveBeenCalledWith('system-err')
+      expect(systemErrElement.cdata).toHaveBeenCalledWith('Error with screenshot')
+      expect(systemErrElement.txt).toHaveBeenCalledWith('[[ATTACHMENT|absolute/path/to/attachment]]')
 
 
   describe 'failure counting', ->

--- a/src/test_case.js
+++ b/src/test_case.js
@@ -8,6 +8,7 @@ function TestCase() {
   this._attributes = {};
   this._errorAttributes = {};
   this._failureAttributes = {};
+  this._errorAttachment = undefined;
 }
 
 TestCase.prototype.className = function (className) {
@@ -74,6 +75,11 @@ TestCase.prototype.getSkippedCount = function () {
   return Number(this._skipped);
 };
 
+TestCase.prototype.errorAttachment = function (path) {
+  this._errorAttachment = path;
+  return this;
+};
+
 TestCase.prototype.build = function (parentElement) {
   var testCaseElement = parentElement.ele('testcase', this._attributes);
   if (this._failure) {
@@ -91,8 +97,13 @@ TestCase.prototype.build = function (parentElement) {
   if (this._standardOutput) {
     testCaseElement.ele('system-out').cdata(this._standardOutput);
   }
+  var systemError = undefined;
   if (this._standardError) {
-    testCaseElement.ele('system-err').cdata(this._standardError);
+    systemError = testCaseElement.ele('system-err').cdata(this._standardError);
+
+    if(this._errorAttachment) {
+      systemError.txt(`[[ATTACHMENT|${this._errorAttachment}]]`);
+    }
   }
 };
 

--- a/src/test_case.js
+++ b/src/test_case.js
@@ -102,7 +102,7 @@ TestCase.prototype.build = function (parentElement) {
     systemError = testCaseElement.ele('system-err').cdata(this._standardError);
 
     if(this._errorAttachment) {
-      systemError.txt(`[[ATTACHMENT|${this._errorAttachment}]]`);
+      systemError.txt('[[ATTACHMENT|' + this._errorAttachment + ']]');
     }
   }
 };


### PR DESCRIPTION
This is to implement the ability to add attachments (limited to system-err for now) as explained in the link below, so that they can be picked up by the jenkins plugin.

http://kohsuke.org/?s=junit+attachment