### PR TITLE
1.3.2: Added type/content support for error/failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ License
 Changelog
 ---------
 
+### 1.3.2
+- Added support for emitting the type attribute for error and failure elements of test cases
+- Added support for emitting cdata/content for the error element of a test case
+
 ### 1.3.1
 - Update dependencies to versions without known vulnerabilities.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "junit-report-builder",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "junit-report-builder",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Aimed at making it easier to build Jenkins compatible JUnit XML reports in plugins for testing frameworks",
   "main": "src/index.js",
   "scripts": {

--- a/spec/e2e_spec.coffee
+++ b/spec/e2e_spec.coffee
@@ -67,12 +67,32 @@ describe 'JUnit Report builder', ->
       '  </testcase>')
 
 
+  it 'should produce a root test case with failure and type when reported', ->
+    builder.testCase().failure('it failed', 'the type')
+
+    expect(builder.build()).toBe reportWith(
+      '  <testcase>\n' +
+      '    <failure message="it failed" type="the type"/>\n' +
+      '  </testcase>')
+
+
   it 'should produce a root test case with error when reported', ->
     builder.testCase().error('it errored')
 
     expect(builder.build()).toBe reportWith(
       '  <testcase>\n' +
       '    <error message="it errored"/>\n' +
+      '  </testcase>')
+
+
+  it 'should produce a root test case with error, type and content when reported', ->
+    builder.testCase().error('it errored', 'the type', 'the content')
+
+    expect(builder.build()).toBe reportWith(
+      '  <testcase>\n' +
+      '    <error message="it errored" type="the type">\n' +
+      '      <![CDATA[the content]]>\n' +
+      '    </error>\n' +
       '  </testcase>')
 
 

--- a/src/test_case.js
+++ b/src/test_case.js
@@ -9,6 +9,7 @@ function TestCase() {
   this._errorAttributes = {};
   this._failureAttributes = {};
   this._errorAttachment = undefined;
+  this._errorContent = undefined;
 }
 
 TestCase.prototype.className = function (className) {
@@ -26,18 +27,27 @@ TestCase.prototype.time = function (timeInSeconds) {
   return this;
 };
 
-TestCase.prototype.failure = function (message) {
+TestCase.prototype.failure = function (message, type) {
   this._failure = true;
   if (message) {
     this._failureAttributes.message = message;
   }
+  if (type) {
+    this._failureAttributes.type = type;
+  }
   return this;
 };
 
-TestCase.prototype.error = function (message) {
+TestCase.prototype.error = function (message, type, content) {
   this._error = true;
   if (message) {
     this._errorAttributes.message = message;
+  }
+  if (type) {
+    this._errorAttributes.type = type;
+  }
+  if (content) {
+    this._errorContent = content;
   }
   return this;
 };
@@ -90,6 +100,9 @@ TestCase.prototype.build = function (parentElement) {
   }
   if (this._error) {
     var errorElement = testCaseElement.ele('error', this._errorAttributes);
+    if (this._errorContent) {
+      errorElement.cdata(this._errorContent);
+    }
   }
   if (this._skipped) {
     testCaseElement.ele('skipped');


### PR DESCRIPTION
Added support for type attributes on error and failure elements and
added support for content/cdata on the error element.

Incremented version to 1.3.2 and updated release notes.