### PR TITLE
Add file attribute to testcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ License
 Changelog
 ---------
 
+### 2.1.0
+- Added support for adding a `file` attribute to a test case
+
 ### 2.0.0
 - Replace mkdirp by make-dir to resolve [npm advisory 1179](https://www.npmjs.com/advisories/1179).
 - Dropped support for node.js 0.10.x and 0.12.x

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "junit-report-builder",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Aimed at making it easier to build Jenkins compatible JUnit XML reports in plugins for testing frameworks",
   "main": "src/index.js",
   "scripts": {

--- a/spec/e2e_spec.coffee
+++ b/spec/e2e_spec.coffee
@@ -23,7 +23,7 @@ describe 'JUnit Report builder', ->
     builder.testCase().className("root.test.Class1")
     suite1 = builder.testSuite().name("first.Suite")
     suite1.testCase().name("Second test")
-    suite1.testCase().className("suite1.test.Class2").name("Third test")
+    suite1.testCase().className("suite1.test.Class2").name("Third test").file("./path-to/the-test-file.coffee")
     suite2 = builder.testSuite().name("second.Suite")
     suite2.testCase().failure("Failure message")
     suite2.testCase().stacktrace("Stacktrace")

--- a/spec/expected_report.xml
+++ b/spec/expected_report.xml
@@ -3,7 +3,7 @@
   <testcase classname="root.test.Class1"/>
   <testsuite name="first.Suite" tests="2" failures="0" errors="0" skipped="0">
     <testcase name="Second test"/>
-    <testcase classname="suite1.test.Class2" name="Third test"/>
+    <testcase classname="suite1.test.Class2" name="Third test" file="./path-to/the-test-file.coffee"/>
   </testsuite>
   <testsuite name="second.Suite" tests="3" failures="2" errors="0" skipped="1">
     <testcase>

--- a/spec/test_case_spec.coffee
+++ b/spec/test_case_spec.coffee
@@ -73,6 +73,16 @@ describe 'Test Case builder', ->
     })
 
 
+  it 'should add the provided file as an attribute', ->
+    testCase.file './path-to/the-test-file.coffee'
+
+    testCase.build parentElement
+
+    expect(parentElement.ele).toHaveBeenCalledWith('testcase', {
+      file: './path-to/the-test-file.coffee'
+    })
+
+
   it 'should add a failure node when test failed', ->
     testCase.failure()
 

--- a/src/test_case.js
+++ b/src/test_case.js
@@ -27,6 +27,11 @@ TestCase.prototype.time = function (timeInSeconds) {
   return this;
 };
 
+TestCase.prototype.file = function (filepath) {
+  this._attributes.file = filepath;
+  return this;
+};
+
 TestCase.prototype.failure = function (message, type) {
   this._failure = true;
   if (message) {


### PR DESCRIPTION
Hi 👋 

I'm looking to add a `file` attribute to each `testcase` node. This will allow use to take full advantage CircleCI's [test splitting feature](https://circleci.com/docs/2.0/parallelism-faster-jobs/#using-the-circleci-cli-to-split-tests).

Without this attribute, CircleCI is unable to match a testcase to a test file and won't be able to optimise accordingly.