### PR TITLE
Convert to classes and add suitenames attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Please refer to the [e2e_spec.coffee](spec/e2e_spec.coffee) for more details on 
 
 ## Changelog
 
+### 3.2.0
+
+-   Support name and test count attributes for the root test suites element. Thanks to [Simeon Cheeseman](https://github.com/SimeonC).
+-   Describe parameter types and return types with JSDoc. Thanks to [Simeon Cheeseman](https://github.com/SimeonC).
+
 ### 3.1.0
 
 -   Add support for generic properties for test cases. Thanks to [Pietro Ferrulli](https://github.com/Pi-fe).

--- a/spec/e2e_spec.js
+++ b/spec/e2e_spec.js
@@ -60,12 +60,13 @@ describe('JUnit Report builder', function () {
     expect(actual).toBe(expected);
   });
 
-  it('should produce an empty list of test suites when nothing reported', () =>
+  it('should produce an empty list of test suites when nothing reported', () => {
     expect(builder.build()).toBe(
       // prettier-ignore
       '<?xml version="1.0" encoding="UTF-8"?>\n' +
       '<testsuites tests="0" failures="0" errors="0" skipped="0"/>',
-    ));
+    );
+  });
 
   it('should set testsuites name', () => {
     builder.name('testSuitesName');

--- a/spec/e2e_spec.js
+++ b/spec/e2e_spec.js
@@ -14,8 +14,28 @@ describe('JUnit Report builder', function () {
     }),
   );
 
-  const reportWith = (content) =>
-    '<?xml version="1.0" encoding="UTF-8"?>\n' + '<testsuites>\n' + content + '\n' + '</testsuites>';
+  const parseProperties = (properties = {}) => {
+    let result = '';
+    ['tests', 'failures', 'errors', 'skipped'].forEach((key) => {
+      result += key + '="' + (properties[key] || 0) + '" ';
+    });
+    for (const key in properties) {
+      if (['tests', 'failures', 'errors', 'skipped'].includes(key)) {
+        continue;
+      }
+      result += key + '="' + properties[key] + '" ';
+    }
+    return result.trim();
+  };
+
+  const reportWith = (content, testSuitesProperties) =>
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<testsuites ' +
+    parseProperties(testSuitesProperties) +
+    '>\n' +
+    content +
+    '\n' +
+    '</testsuites>';
 
   it('should produce a report identical to the expected one', function () {
     builder.testCase().className('root.test.Class1');
@@ -44,8 +64,17 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       // prettier-ignore
       '<?xml version="1.0" encoding="UTF-8"?>\n' +
-      '<testsuites/>',
+      '<testsuites tests="0" failures="0" errors="0" skipped="0"/>',
     ));
+
+  it('should set testsuites name', () => {
+    builder.testSuites().name('testSuitesName');
+    expect(builder.build()).toBe(
+      // prettier-ignore
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      '<testsuites name="testSuitesName" tests="0" failures="0" errors="0" skipped="0"/>',
+    );
+  });
 
   it('should produce an empty test suite when a test suite reported', function () {
     builder.testSuite();
@@ -54,6 +83,7 @@ describe('JUnit Report builder', function () {
       reportWith(
         // prettier-ignore
         '  <testsuite tests="0" failures="0" errors="0" skipped="0"/>',
+        { tests: 0, failures: 0, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -65,6 +95,7 @@ describe('JUnit Report builder', function () {
       reportWith(
         // prettier-ignore
         '  <testcase/>',
+        { tests: 1, failures: 0, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -78,6 +109,7 @@ describe('JUnit Report builder', function () {
         '  <testcase>\n' +
         '    <failure message="it failed"/>\n' +
         '  </testcase>',
+        { tests: 1, failures: 1, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -91,6 +123,7 @@ describe('JUnit Report builder', function () {
         '  <testcase>\n' +
         '    <failure message="it failed" type="the type"/>\n' +
         '  </testcase>',
+        { tests: 1, failures: 1, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -104,6 +137,7 @@ describe('JUnit Report builder', function () {
         '  <testcase>\n' +
         '    <error message="it errored"/>\n' +
         '  </testcase>',
+        { tests: 1, failures: 0, errors: 1, skipped: 0 },
       ),
     );
   });
@@ -117,6 +151,7 @@ describe('JUnit Report builder', function () {
         '  <testcase>\n' +
         '    <error message="it errored" type="the type"><![CDATA[the content]]></error>\n' +
         '  </testcase>',
+        { tests: 1, failures: 0, errors: 1, skipped: 0 },
       ),
     );
   });
@@ -130,6 +165,7 @@ describe('JUnit Report builder', function () {
         '  <testsuite tests="1" failures="0" errors="0" skipped="0">\n' +
         '    <testcase/>\n' +
         '  </testsuite>',
+        { tests: 1, failures: 0, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -145,6 +181,7 @@ describe('JUnit Report builder', function () {
         '      <failure/>\n' +
         '    </testcase>\n' +
         '  </testsuite>',
+        { tests: 1, failures: 1, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -160,6 +197,7 @@ describe('JUnit Report builder', function () {
         '      <error/>\n' +
         '    </testcase>\n' +
         '  </testsuite>',
+        { tests: 1, failures: 0, errors: 1, skipped: 0 },
       ),
     );
   });
@@ -175,6 +213,7 @@ describe('JUnit Report builder', function () {
         '      <skipped/>\n' +
         '    </testcase>\n' +
         '  </testsuite>',
+        { tests: 1, failures: 0, errors: 0, skipped: 1 },
       ),
     );
   });
@@ -210,6 +249,7 @@ describe('JUnit Report builder', function () {
         '  <testsuite tests="1" failures="0" errors="0" skipped="0">\n' +
         '    <testcase time="2.5"/>\n' +
         '  </testsuite>',
+        { tests: 1, failures: 0, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -225,6 +265,7 @@ describe('JUnit Report builder', function () {
         '      <system-out><![CDATA[This was written to stdout!]]></system-out>\n' +
         '    </testcase>\n' +
         '  </testsuite>',
+        { tests: 1, failures: 0, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -240,6 +281,7 @@ describe('JUnit Report builder', function () {
         '      <system-err><![CDATA[This was written to stderr!]]></system-err>\n' +
         '    </testcase>\n' +
         '  </testsuite>',
+        { tests: 1, failures: 0, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -262,6 +304,7 @@ describe('JUnit Report builder', function () {
         '      </system-err>\n' +
         '    </testcase>\n' +
         '  </testsuite>',
+        { tests: 1, failures: 0, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -277,6 +320,7 @@ describe('JUnit Report builder', function () {
         '  <testcase name="1"/>\n' +
         '  <testsuite name="2" tests="0" failures="0" errors="0" skipped="0"/>\n' +
         '  <testcase name="3"/>',
+        { tests: 2, failures: 0, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -290,6 +334,7 @@ describe('JUnit Report builder', function () {
         '  <testcase>\n' +
         '    <system-out><![CDATA[Emoji: 🤦]]></system-out>\n' +
         '  </testcase>',
+        { tests: 1, failures: 0, errors: 0, skipped: 0 },
       ),
     );
   });
@@ -303,6 +348,7 @@ describe('JUnit Report builder', function () {
         '  <testcase>\n' +
         '    <error message="it is &quot;quoted&quot;"/>\n' +
         '  </testcase>',
+        { tests: 1, failures: 0, errors: 1, skipped: 0 },
       ),
     );
   });
@@ -316,6 +362,7 @@ describe('JUnit Report builder', function () {
         '  <testcase>\n' +
         '    <error message="InvalidCharactersStripped"/>\n' +
         '  </testcase>',
+        { tests: 1, failures: 0, errors: 1, skipped: 0 },
       ),
     );
   });

--- a/spec/e2e_spec.js
+++ b/spec/e2e_spec.js
@@ -28,14 +28,7 @@ describe('JUnit Report builder', function () {
     return result.trim();
   };
 
-  const reportWith = (content, testSuitesProperties) =>
-    '<?xml version="1.0" encoding="UTF-8"?>\n' +
-    '<testsuites ' +
-    parseProperties(testSuitesProperties) +
-    '>\n' +
-    content +
-    '\n' +
-    '</testsuites>';
+  const reportWith = (content, testSuitesProperties) => '<?xml version="1.0" encoding="UTF-8"?>\n' + content;
 
   it('should produce a report identical to the expected one', function () {
     builder.testCase().className('root.test.Class1');
@@ -83,8 +76,9 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
-        '  <testsuite tests="0" failures="0" errors="0" skipped="0"/>',
-        { tests: 0, failures: 0, errors: 0, skipped: 0 },
+        '<testsuites tests="0" failures="0" errors="0" skipped="0">\n' +
+        '  <testsuite tests="0" failures="0" errors="0" skipped="0"/>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -95,8 +89,9 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
-        '  <testcase/>',
-        { tests: 1, failures: 0, errors: 0, skipped: 0 },
+        '<testsuites tests="1" failures="0" errors="0" skipped="0">\n' +
+        '  <testcase/>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -107,10 +102,11 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="1" errors="0" skipped="0">\n' +
         '  <testcase>\n' +
         '    <failure message="it failed"/>\n' +
-        '  </testcase>',
-        { tests: 1, failures: 1, errors: 0, skipped: 0 },
+        '  </testcase>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -121,10 +117,11 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="1" errors="0" skipped="0">\n' +
         '  <testcase>\n' +
         '    <failure message="it failed" type="the type"/>\n' +
-        '  </testcase>',
-        { tests: 1, failures: 1, errors: 0, skipped: 0 },
+        '  </testcase>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -135,10 +132,11 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="1" skipped="0">\n' +
         '  <testcase>\n' +
         '    <error message="it errored"/>\n' +
-        '  </testcase>',
-        { tests: 1, failures: 0, errors: 1, skipped: 0 },
+        '  </testcase>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -149,10 +147,11 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="1" skipped="0">\n' +
         '  <testcase>\n' +
         '    <error message="it errored" type="the type"><![CDATA[the content]]></error>\n' +
-        '  </testcase>',
-        { tests: 1, failures: 0, errors: 1, skipped: 0 },
+        '  </testcase>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -163,10 +162,11 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="0" skipped="0">\n' +
         '  <testsuite tests="1" failures="0" errors="0" skipped="0">\n' +
         '    <testcase/>\n' +
-        '  </testsuite>',
-        { tests: 1, failures: 0, errors: 0, skipped: 0 },
+        '  </testsuite>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -177,12 +177,13 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="1" errors="0" skipped="0">\n' +
         '  <testsuite tests="1" failures="1" errors="0" skipped="0">\n' +
         '    <testcase>\n' +
         '      <failure/>\n' +
         '    </testcase>\n' +
-        '  </testsuite>',
-        { tests: 1, failures: 1, errors: 0, skipped: 0 },
+        '  </testsuite>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -193,12 +194,13 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="1" skipped="0">\n' +
         '  <testsuite tests="1" failures="0" errors="1" skipped="0">\n' +
         '    <testcase>\n' +
         '      <error/>\n' +
         '    </testcase>\n' +
-        '  </testsuite>',
-        { tests: 1, failures: 0, errors: 1, skipped: 0 },
+        '  </testsuite>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -209,12 +211,13 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="0" skipped="1">\n' +
         '  <testsuite tests="1" failures="0" errors="0" skipped="1">\n' +
         '    <testcase>\n' +
         '      <skipped/>\n' +
         '    </testcase>\n' +
-        '  </testsuite>',
-        { tests: 1, failures: 0, errors: 0, skipped: 1 },
+        '  </testsuite>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -225,7 +228,9 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
-        '  <testsuite time="2.5" tests="0" failures="0" errors="0" skipped="0"/>',
+        '<testsuites tests="0" failures="0" errors="0" skipped="0">\n' +
+        '  <testsuite time="2.5" tests="0" failures="0" errors="0" skipped="0"/>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -236,7 +241,9 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
-        '  <testsuite timestamp="2015-11-22T13:37:59" tests="0" failures="0" errors="0" skipped="0"/>',
+        '<testsuites tests="0" failures="0" errors="0" skipped="0">\n' +
+        '  <testsuite timestamp="2015-11-22T13:37:59" tests="0" failures="0" errors="0" skipped="0"/>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -247,10 +254,11 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="0" skipped="0">\n' +
         '  <testsuite tests="1" failures="0" errors="0" skipped="0">\n' +
         '    <testcase time="2.5"/>\n' +
-        '  </testsuite>',
-        { tests: 1, failures: 0, errors: 0, skipped: 0 },
+        '  </testsuite>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -261,12 +269,13 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="0" skipped="0">\n' +
         '  <testsuite tests="1" failures="0" errors="0" skipped="0">\n' +
         '    <testcase>\n' +
         '      <system-out><![CDATA[This was written to stdout!]]></system-out>\n' +
         '    </testcase>\n' +
-        '  </testsuite>',
-        { tests: 1, failures: 0, errors: 0, skipped: 0 },
+        '  </testsuite>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -277,12 +286,13 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="0" skipped="0">\n' +
         '  <testsuite tests="1" failures="0" errors="0" skipped="0">\n' +
         '    <testcase>\n' +
         '      <system-err><![CDATA[This was written to stderr!]]></system-err>\n' +
         '    </testcase>\n' +
-        '  </testsuite>',
-        { tests: 1, failures: 0, errors: 0, skipped: 0 },
+        '  </testsuite>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -297,6 +307,7 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="0" skipped="0">\n' +
         '  <testsuite tests="1" failures="0" errors="0" skipped="0">\n' +
         '    <testcase>\n' +
         '      <system-err>\n' +
@@ -304,8 +315,8 @@ describe('JUnit Report builder', function () {
         '        [[ATTACHMENT|absolute/path/to/attachment]]\n' +
         '      </system-err>\n' +
         '    </testcase>\n' +
-        '  </testsuite>',
-        { tests: 1, failures: 0, errors: 0, skipped: 0 },
+        '  </testsuite>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -318,10 +329,11 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="2" failures="0" errors="0" skipped="0">\n' +
         '  <testcase name="1"/>\n' +
         '  <testsuite name="2" tests="0" failures="0" errors="0" skipped="0"/>\n' +
-        '  <testcase name="3"/>',
-        { tests: 2, failures: 0, errors: 0, skipped: 0 },
+        '  <testcase name="3"/>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -332,10 +344,11 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="0" skipped="0">\n' +
         '  <testcase>\n' +
         '    <system-out><![CDATA[Emoji: 🤦]]></system-out>\n' +
-        '  </testcase>',
-        { tests: 1, failures: 0, errors: 0, skipped: 0 },
+        '  </testcase>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -346,10 +359,11 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="1" skipped="0">\n' +
         '  <testcase>\n' +
         '    <error message="it is &quot;quoted&quot;"/>\n' +
-        '  </testcase>',
-        { tests: 1, failures: 0, errors: 1, skipped: 0 },
+        '  </testcase>\n' +
+        '</testsuites>',
       ),
     );
   });
@@ -360,10 +374,11 @@ describe('JUnit Report builder', function () {
     expect(builder.build()).toBe(
       reportWith(
         // prettier-ignore
+        '<testsuites tests="1" failures="0" errors="1" skipped="0">\n' +
         '  <testcase>\n' +
         '    <error message="InvalidCharactersStripped"/>\n' +
-        '  </testcase>',
-        { tests: 1, failures: 0, errors: 1, skipped: 0 },
+        '  </testcase>\n' +
+        '</testsuites>',
       ),
     );
   });

--- a/spec/e2e_spec.js
+++ b/spec/e2e_spec.js
@@ -68,7 +68,7 @@ describe('JUnit Report builder', function () {
     ));
 
   it('should set testsuites name', () => {
-    builder.testSuites().name('testSuitesName');
+    builder.name('testSuitesName');
     expect(builder.build()).toBe(
       // prettier-ignore
       '<?xml version="1.0" encoding="UTF-8"?>\n' +

--- a/spec/expected_report.xml
+++ b/spec/expected_report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites tests="6" failures="2" errors="0" skipped="1">
   <testcase classname="root.test.Class1"/>
   <testsuite name="first.Suite" tests="2" failures="0" errors="0" skipped="0">
     <testcase name="Second test"/>

--- a/spec/test_case_spec.js
+++ b/spec/test_case_spec.js
@@ -1,4 +1,4 @@
-const TestCase = require('../src/test_case');
+const { TestCase } = require('../src/test_case');
 
 describe('Test Case builder', function () {
   let testCase = null;

--- a/spec/test_suite_spec.js
+++ b/spec/test_suite_spec.js
@@ -1,4 +1,4 @@
-const TestSuite = require('../src/test_suite');
+const { TestSuite } = require('../src/test_suite');
 
 describe('Test Suite builder', function () {
   let testSuite = null;
@@ -9,7 +9,13 @@ describe('Test Suite builder', function () {
 
   beforeEach(function () {
     const factory = jasmine.createSpyObj('factory', ['newTestCase']);
-    testCase = jasmine.createSpyObj('testCase', ['build', 'getFailureCount', 'getErrorCount', 'getSkippedCount']);
+    testCase = jasmine.createSpyObj('testCase', [
+      'build',
+      'getFailureCount',
+      'getErrorCount',
+      'getSkippedCount',
+      'getTestCaseCount',
+    ]);
 
     factory.newTestCase.and.callFake(() => testCase);
 
@@ -32,6 +38,8 @@ describe('Test Suite builder', function () {
           return propertiesElement;
       }
     });
+
+    testCase.getTestCaseCount.and.callFake(() => 1);
 
     testCase.getFailureCount.and.callFake(() => 0);
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -54,7 +54,7 @@ class JUnitReportBuilder {
    * @returns {JUnitReportBuilder}
    */
   newBuilder() {
-    return new JUnitReportBuilder(this._factory);
+    return this._factory.newBuilder();
   }
 }
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -1,3 +1,4 @@
+// @ts-check
 var _ = require('lodash');
 var xmlBuilder = require('xmlbuilder');
 var path = require('path');
@@ -6,38 +7,58 @@ var fs = require('fs');
 var TestSuite = require('./test_suite');
 var TestCase = require('./test_case');
 
-function JUnitReportBuilder(factory) {
-  this._factory = factory;
-  this._testSuitesAndCases = [];
+class JUnitReportBuilder {
+  /**
+   * @param {import('./factory')} factory
+   */
+  constructor(factory) {
+    this._factory = factory;
+    this._testSuitesAndCases = [];
+  }
+
+  /**
+   * @param {string} reportPath
+   */
+  writeTo(reportPath) {
+    makeDir.sync(path.dirname(reportPath));
+    fs.writeFileSync(reportPath, this.build(), 'utf8');
+  }
+
+  /**
+   * @returns {string} xml file content
+   */
+  build() {
+    var xmlTree = xmlBuilder.create('testsuites', { encoding: 'UTF-8', invalidCharReplacement: '' });
+    _.forEach(this._testSuitesAndCases, function (suiteOrCase) {
+      suiteOrCase.build(xmlTree);
+    });
+    return xmlTree.end({ pretty: true });
+  }
+
+  /**
+   * @returns {import('./test_suite')}
+   */
+  testSuite() {
+    var suite = this._factory.newTestSuite();
+    this._testSuitesAndCases.push(suite);
+    return suite;
+  }
+
+  /**
+   * @returns {import('./test_case')}
+   */
+  testCase() {
+    var testCase = this._factory.newTestCase();
+    this._testSuitesAndCases.push(testCase);
+    return testCase;
+  }
+
+  /**
+   * @returns {ReturnType<import('./factory')['newBuilder']>}
+   */
+  newBuilder() {
+    return this._factory.newBuilder();
+  }
 }
-
-JUnitReportBuilder.prototype.writeTo = function (reportPath) {
-  makeDir.sync(path.dirname(reportPath));
-  fs.writeFileSync(reportPath, this.build(), 'utf8');
-};
-
-JUnitReportBuilder.prototype.build = function () {
-  var xmlTree = xmlBuilder.create('testsuites', { encoding: 'UTF-8', invalidCharReplacement: '' });
-  _.forEach(this._testSuitesAndCases, function (suiteOrCase) {
-    suiteOrCase.build(xmlTree);
-  });
-  return xmlTree.end({ pretty: true });
-};
-
-JUnitReportBuilder.prototype.testSuite = function () {
-  var suite = this._factory.newTestSuite();
-  this._testSuitesAndCases.push(suite);
-  return suite;
-};
-
-JUnitReportBuilder.prototype.testCase = function () {
-  var testCase = this._factory.newTestCase();
-  this._testSuitesAndCases.push(testCase);
-  return testCase;
-};
-
-JUnitReportBuilder.prototype.newBuilder = function () {
-  return this._factory.newBuilder();
-};
 
 module.exports = JUnitReportBuilder;

--- a/src/builder.js
+++ b/src/builder.js
@@ -30,10 +30,13 @@ class JUnitReportBuilder {
   }
 
   /**
-   * @returns {import('./test_suites').TestSuites}
+   * @param {string} name
+   * @returns {JUnitReportBuilder}
+   * @chainable
    */
-  testSuites() {
-    return this._rootTestSuites;
+  name(name) {
+    this._rootTestSuites.name(name);
+    return this;
   }
 
   /**

--- a/src/builder.js
+++ b/src/builder.js
@@ -1,19 +1,16 @@
 // @ts-check
-var _ = require('lodash');
-var xmlBuilder = require('xmlbuilder');
 var path = require('path');
 var makeDir = require('make-dir');
 var fs = require('fs');
-var TestSuite = require('./test_suite');
-var TestCase = require('./test_case');
+var { TestSuites } = require('./test_suites');
 
 class JUnitReportBuilder {
   /**
-   * @param {import('./factory')} factory
+   * @param {import('./factory').Factory} factory
    */
   constructor(factory) {
     this._factory = factory;
-    this._testSuitesAndCases = [];
+    this._rootTestSuites = new TestSuites(factory);
   }
 
   /**
@@ -25,40 +22,40 @@ class JUnitReportBuilder {
   }
 
   /**
-   * @returns {string} xml file content
+   * @returns {string}
    */
   build() {
-    var xmlTree = xmlBuilder.create('testsuites', { encoding: 'UTF-8', invalidCharReplacement: '' });
-    _.forEach(this._testSuitesAndCases, function (suiteOrCase) {
-      suiteOrCase.build(xmlTree);
-    });
+    var xmlTree = this._rootTestSuites.build();
     return xmlTree.end({ pretty: true });
   }
 
   /**
-   * @returns {import('./test_suite')}
+   * @returns {import('./test_suites').TestSuites}
+   */
+  testSuites() {
+    return this._rootTestSuites;
+  }
+
+  /**
+   * @returns {import('./test_suite').TestSuite}
    */
   testSuite() {
-    var suite = this._factory.newTestSuite();
-    this._testSuitesAndCases.push(suite);
-    return suite;
+    return this._rootTestSuites.testSuite();
   }
 
   /**
-   * @returns {import('./test_case')}
+   * @returns {import('./test_case').TestCase}
    */
   testCase() {
-    var testCase = this._factory.newTestCase();
-    this._testSuitesAndCases.push(testCase);
-    return testCase;
+    return this._rootTestSuites.testCase();
   }
 
   /**
-   * @returns {ReturnType<import('./factory')['newBuilder']>}
+   * @returns {JUnitReportBuilder}
    */
   newBuilder() {
-    return this._factory.newBuilder();
+    return new JUnitReportBuilder(this._factory);
   }
 }
 
-module.exports = JUnitReportBuilder;
+module.exports = { Builder: JUnitReportBuilder };

--- a/src/factory.js
+++ b/src/factory.js
@@ -2,18 +2,29 @@ var Builder = require('./builder');
 var TestSuite = require('./test_suite');
 var TestCase = require('./test_case');
 
-function Factory() {}
+class Factory {
+  constructor() {}
 
-Factory.prototype.newBuilder = function () {
-  return new Builder(this);
-};
+  /**
+   * @returns {Builder}
+   */
+  newBuilder() {
+    return new Builder(this);
+  }
 
-Factory.prototype.newTestSuite = function () {
-  return new TestSuite(this);
-};
+  /**
+   * @returns {TestSuite}
+   */
+  newTestSuite() {
+    return new TestSuite(this);
+  }
 
-Factory.prototype.newTestCase = function () {
-  return new TestCase(this);
-};
+  /**
+   * @returns {TestCase}
+   */
+  newTestCase() {
+    return new TestCase(this);
+  }
+}
 
 module.exports = Factory;

--- a/src/factory.js
+++ b/src/factory.js
@@ -1,30 +1,36 @@
-var Builder = require('./builder');
-var TestSuite = require('./test_suite');
-var TestCase = require('./test_case');
+var { Builder } = require('./builder');
+var { TestSuites } = require('./test_suites');
+var { TestSuite } = require('./test_suite');
+var { TestCase } = require('./test_case');
 
 class Factory {
-  constructor() {}
-
   /**
-   * @returns {Builder}
+   * @returns {import('./builder').Builder}
    */
   newBuilder() {
     return new Builder(this);
   }
 
   /**
-   * @returns {TestSuite}
+   * @returns {import('./test_suite').TestSuite}
    */
   newTestSuite() {
     return new TestSuite(this);
   }
 
   /**
-   * @returns {TestCase}
+   * @returns {import('./test_case').TestCase}
    */
   newTestCase() {
     return new TestCase(this);
   }
+
+  /**
+   * @returns {import('./test_suites').TestSuites}
+   */
+  newTestSuites() {
+    return new TestSuites(this);
+  }
 }
 
-module.exports = Factory;
+module.exports = { Factory: Factory };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-var Factory = require('./factory');
+var { Factory } = require('./factory');
 
 module.exports = new Factory().newBuilder();

--- a/src/test_case.js
+++ b/src/test_case.js
@@ -1,50 +1,28 @@
 // @ts-check
 var _ = require('lodash');
-class TestCase {
-  constructor() {
+var { TestNode } = require('./test_node');
+
+class TestCase extends TestNode {
+  /**
+   * @param {import('./factory').Factory} factory
+   */
+  constructor(factory) {
+    super(factory, 'testcase');
     this._error = false;
     this._failure = false;
     this._skipped = false;
     this._standardOutput = undefined;
     this._standardError = undefined;
     this._stacktrace = undefined;
-    this._attributes = {};
     this._errorAttributes = {};
     this._failureAttributes = {};
     this._errorAttachment = undefined;
     this._errorContent = undefined;
-    this._properties = [];
-  }
-
-  /**
-   * @param {string} className
-   * @chainable
-   */
-  className(className) {
-    this._attributes.classname = className;
-    return this;
-  }
-
-  /**
-   * @param {string} name
-   * @chainable
-   */
-  name(name) {
-    this._attributes.name = name;
-    return this;
-  }
-
-  /**
-   * @param {number} timeInSeconds
-   * @chainable
-   */
-  time(timeInSeconds) {
-    this._attributes.time = timeInSeconds;
-    return this;
   }
 
   /**
    * @param {string} filepath
+   * @returns {TestCase}
    * @chainable
    */
   file(filepath) {
@@ -53,8 +31,9 @@ class TestCase {
   }
 
   /**
-   * @param {string} message
-   * @param {string} type
+   * @param {string} [message]
+   * @param {string} [type]
+   * @returns {TestCase}
    * @chainable
    */
   failure(message, type) {
@@ -69,9 +48,10 @@ class TestCase {
   }
 
   /**
-   * @param {string} message
-   * @param {string} type
-   * @param {string} content
+   * @param {string} [message]
+   * @param {string} [type]
+   * @param {string} [content]
+   * @returns {TestCase}
    * @chainable
    */
   error(message, type, content) {
@@ -89,7 +69,8 @@ class TestCase {
   }
 
   /**
-   * @param {string} stacktrace
+   * @param {string} [stacktrace]
+   * @returns {TestCase}
    * @chainable
    */
   stacktrace(stacktrace) {
@@ -99,6 +80,7 @@ class TestCase {
   }
 
   /**
+   * @returns {TestCase}
    * @chainable
    */
   skipped() {
@@ -107,7 +89,8 @@ class TestCase {
   }
 
   /**
-   * @param {string} log
+   * @param {string} [log]
+   * @returns {TestCase}
    * @chainable
    */
   standardOutput(log) {
@@ -116,12 +99,20 @@ class TestCase {
   }
 
   /**
-   * @param {string} log
+   * @param {string} [log]
+   * @returns {TestCase}
    * @chainable
    */
   standardError(log) {
     this._standardError = log;
     return this;
+  }
+
+  /**
+   * @returns {number}
+   */
+  getTestCaseCount() {
+    return 1;
   }
 
   /**
@@ -146,7 +137,9 @@ class TestCase {
   }
 
   /**
+   *
    * @param {string} path
+   * @returns {TestCase}
    * @chainable
    */
   errorAttachment(path) {
@@ -155,29 +148,10 @@ class TestCase {
   }
 
   /**
-   * @param {string} name
-   * @param {string} value
-   * @chainable
-   */
-  property(name, value) {
-    this._properties.push({ name: name, value: value });
-    return this;
-  }
-
-  /**
    * @param {import('xmlbuilder').XMLElement} parentElement
    */
   build(parentElement) {
-    var testCaseElement = parentElement.ele('testcase', this._attributes);
-    if (this._properties.length) {
-      var propertiesElement = testCaseElement.ele('properties');
-      _.forEach(this._properties, function (property) {
-        propertiesElement.ele('property', {
-          name: property.name,
-          value: property.value,
-        });
-      });
-    }
+    const testCaseElement = this.buildNode(this.createNode(parentElement));
     if (this._failure) {
       var failureElement = testCaseElement.ele('failure', this._failureAttributes);
       if (this._stacktrace) {
@@ -204,7 +178,8 @@ class TestCase {
         systemError.txt('[[ATTACHMENT|' + this._errorAttachment + ']]');
       }
     }
+    return testCaseElement;
   }
 }
 
-module.exports = TestCase;
+module.exports = { TestCase: TestCase };

--- a/src/test_case.js
+++ b/src/test_case.js
@@ -1,144 +1,210 @@
+// @ts-check
 var _ = require('lodash');
-function TestCase() {
-  this._error = false;
-  this._failure = false;
-  this._skipped = false;
-  this._standardOutput = undefined;
-  this._standardError = undefined;
-  this._stacktrace = undefined;
-  this._attributes = {};
-  this._errorAttributes = {};
-  this._failureAttributes = {};
-  this._errorAttachment = undefined;
-  this._errorContent = undefined;
-  this._properties = [];
-}
-
-TestCase.prototype.className = function (className) {
-  this._attributes.classname = className;
-  return this;
-};
-
-TestCase.prototype.name = function (name) {
-  this._attributes.name = name;
-  return this;
-};
-
-TestCase.prototype.time = function (timeInSeconds) {
-  this._attributes.time = timeInSeconds;
-  return this;
-};
-
-TestCase.prototype.file = function (filepath) {
-  this._attributes.file = filepath;
-  return this;
-};
-
-TestCase.prototype.failure = function (message, type) {
-  this._failure = true;
-  if (message) {
-    this._failureAttributes.message = message;
+class TestCase {
+  constructor() {
+    this._error = false;
+    this._failure = false;
+    this._skipped = false;
+    this._standardOutput = undefined;
+    this._standardError = undefined;
+    this._stacktrace = undefined;
+    this._attributes = {};
+    this._errorAttributes = {};
+    this._failureAttributes = {};
+    this._errorAttachment = undefined;
+    this._errorContent = undefined;
+    this._properties = [];
   }
-  if (type) {
-    this._failureAttributes.type = type;
+
+  /**
+   * @param {string} className
+   * @chainable
+   */
+  className(className) {
+    this._attributes.classname = className;
+    return this;
   }
-  return this;
-};
 
-TestCase.prototype.error = function (message, type, content) {
-  this._error = true;
-  if (message) {
-    this._errorAttributes.message = message;
+  /**
+   * @param {string} name
+   * @chainable
+   */
+  name(name) {
+    this._attributes.name = name;
+    return this;
   }
-  if (type) {
-    this._errorAttributes.type = type;
+
+  /**
+   * @param {number} timeInSeconds
+   * @chainable
+   */
+  time(timeInSeconds) {
+    this._attributes.time = timeInSeconds;
+    return this;
   }
-  if (content) {
-    this._errorContent = content;
+
+  /**
+   * @param {string} filepath
+   * @chainable
+   */
+  file(filepath) {
+    this._attributes.file = filepath;
+    return this;
   }
-  return this;
-};
 
-TestCase.prototype.stacktrace = function (stacktrace) {
-  this._failure = true;
-  this._stacktrace = stacktrace;
-  return this;
-};
+  /**
+   * @param {string} message
+   * @param {string} type
+   * @chainable
+   */
+  failure(message, type) {
+    this._failure = true;
+    if (message) {
+      this._failureAttributes.message = message;
+    }
+    if (type) {
+      this._failureAttributes.type = type;
+    }
+    return this;
+  }
 
-TestCase.prototype.skipped = function () {
-  this._skipped = true;
-  return this;
-};
+  /**
+   * @param {string} message
+   * @param {string} type
+   * @param {string} content
+   * @chainable
+   */
+  error(message, type, content) {
+    this._error = true;
+    if (message) {
+      this._errorAttributes.message = message;
+    }
+    if (type) {
+      this._errorAttributes.type = type;
+    }
+    if (content) {
+      this._errorContent = content;
+    }
+    return this;
+  }
 
-TestCase.prototype.standardOutput = function (log) {
-  this._standardOutput = log;
-  return this;
-};
+  /**
+   * @param {string} stacktrace
+   * @chainable
+   */
+  stacktrace(stacktrace) {
+    this._failure = true;
+    this._stacktrace = stacktrace;
+    return this;
+  }
 
-TestCase.prototype.standardError = function (log) {
-  this._standardError = log;
-  return this;
-};
+  /**
+   * @chainable
+   */
+  skipped() {
+    this._skipped = true;
+    return this;
+  }
 
-TestCase.prototype.getFailureCount = function () {
-  return Number(this._failure);
-};
+  /**
+   * @param {string} log
+   * @chainable
+   */
+  standardOutput(log) {
+    this._standardOutput = log;
+    return this;
+  }
 
-TestCase.prototype.getErrorCount = function () {
-  return Number(this._error);
-};
+  /**
+   * @param {string} log
+   * @chainable
+   */
+  standardError(log) {
+    this._standardError = log;
+    return this;
+  }
 
-TestCase.prototype.getSkippedCount = function () {
-  return Number(this._skipped);
-};
+  /**
+   * @returns {number}
+   */
+  getFailureCount() {
+    return Number(this._failure);
+  }
 
-TestCase.prototype.errorAttachment = function (path) {
-  this._errorAttachment = path;
-  return this;
-};
+  /**
+   * @returns {number}
+   */
+  getErrorCount() {
+    return Number(this._error);
+  }
 
-TestCase.prototype.property = function (name, value) {
-  this._properties.push({ name: name, value: value });
-  return this;
-};
+  /**
+   * @returns {number}
+   */
+  getSkippedCount() {
+    return Number(this._skipped);
+  }
 
-TestCase.prototype.build = function (parentElement) {
-  var testCaseElement = parentElement.ele('testcase', this._attributes);
-  if (this._properties.length) {
-    var propertiesElement = testCaseElement.ele('properties');
-    _.forEach(this._properties, function (property) {
-      propertiesElement.ele('property', {
-        name: property.name,
-        value: property.value,
+  /**
+   * @param {string} path
+   * @chainable
+   */
+  errorAttachment(path) {
+    this._errorAttachment = path;
+    return this;
+  }
+
+  /**
+   * @param {string} name
+   * @param {string} value
+   * @chainable
+   */
+  property(name, value) {
+    this._properties.push({ name: name, value: value });
+    return this;
+  }
+
+  /**
+   * @param {import('xmlbuilder').XMLElement} parentElement
+   */
+  build(parentElement) {
+    var testCaseElement = parentElement.ele('testcase', this._attributes);
+    if (this._properties.length) {
+      var propertiesElement = testCaseElement.ele('properties');
+      _.forEach(this._properties, function (property) {
+        propertiesElement.ele('property', {
+          name: property.name,
+          value: property.value,
+        });
       });
-    });
-  }
-  if (this._failure) {
-    var failureElement = testCaseElement.ele('failure', this._failureAttributes);
-    if (this._stacktrace) {
-      failureElement.cdata(this._stacktrace);
     }
-  }
-  if (this._error) {
-    var errorElement = testCaseElement.ele('error', this._errorAttributes);
-    if (this._errorContent) {
-      errorElement.cdata(this._errorContent);
+    if (this._failure) {
+      var failureElement = testCaseElement.ele('failure', this._failureAttributes);
+      if (this._stacktrace) {
+        failureElement.cdata(this._stacktrace);
+      }
     }
-  }
-  if (this._skipped) {
-    testCaseElement.ele('skipped');
-  }
-  if (this._standardOutput) {
-    testCaseElement.ele('system-out').cdata(this._standardOutput);
-  }
-  var systemError;
-  if (this._standardError) {
-    systemError = testCaseElement.ele('system-err').cdata(this._standardError);
+    if (this._error) {
+      var errorElement = testCaseElement.ele('error', this._errorAttributes);
+      if (this._errorContent) {
+        errorElement.cdata(this._errorContent);
+      }
+    }
+    if (this._skipped) {
+      testCaseElement.ele('skipped');
+    }
+    if (this._standardOutput) {
+      testCaseElement.ele('system-out').cdata(this._standardOutput);
+    }
+    var systemError;
+    if (this._standardError) {
+      systemError = testCaseElement.ele('system-err').cdata(this._standardError);
 
-    if (this._errorAttachment) {
-      systemError.txt('[[ATTACHMENT|' + this._errorAttachment + ']]');
+      if (this._errorAttachment) {
+        systemError.txt('[[ATTACHMENT|' + this._errorAttachment + ']]');
+      }
     }
   }
-};
+}
 
 module.exports = TestCase;

--- a/src/test_case.js
+++ b/src/test_case.js
@@ -161,7 +161,7 @@ class TestCase extends TestNode {
    * @param {import('xmlbuilder').XMLElement} parentElement
    */
   build(parentElement) {
-    const testCaseElement = this.buildNode(this.createNode(parentElement));
+    const testCaseElement = this.buildNode(this.createElement(parentElement));
     if (this._failure) {
       var failureElement = testCaseElement.ele('failure', this._failureAttributes);
       if (this._stacktrace) {

--- a/src/test_case.js
+++ b/src/test_case.js
@@ -21,6 +21,16 @@ class TestCase extends TestNode {
   }
 
   /**
+   * @param {string} className
+   * @returns {TestCase}
+   * @chainable
+   */
+  className(className) {
+    this._attributes.classname = className;
+    return this;
+  }
+
+  /**
    * @param {string} filepath
    * @returns {TestCase}
    * @chainable

--- a/src/test_group.js
+++ b/src/test_group.js
@@ -75,7 +75,7 @@ class TestGroup extends TestNode {
   /**
    * @protected
    * @param {Function} counterFunction
-   * @returns
+   * @returns {number}
    */
   _sumTestCaseCounts(counterFunction) {
     var counts = _.map(this._children, counterFunction);

--- a/src/test_group.js
+++ b/src/test_group.js
@@ -6,10 +6,10 @@ var { TestNode } = require('./test_node');
 class TestGroup extends TestNode {
   /**
    * @param {import('./factory').Factory} factory
-   * @param {string} nodeName
+   * @param {string} elementName
    */
-  constructor(factory, nodeName) {
-    super(factory, nodeName);
+  constructor(factory, elementName) {
+    super(factory, elementName);
     this._children = [];
   }
 

--- a/src/test_group.js
+++ b/src/test_group.js
@@ -5,6 +5,15 @@ var { TestNode } = require('./test_node');
 
 class TestGroup extends TestNode {
   /**
+   * @param {import('./factory').Factory} factory
+   * @param {string} nodeName
+   */
+  constructor(factory, nodeName) {
+    super(factory, nodeName);
+    this._children = [];
+  }
+
+  /**
    * @param {string|Date} timestamp
    * @returns {TestGroup}
    * @chainable
@@ -83,6 +92,19 @@ class TestGroup extends TestNode {
     this._attributes.errors = this.getErrorCount();
     this._attributes.skipped = this.getSkippedCount();
     return super.build(parentElement);
+  }
+
+  /**
+   * @protected
+   * @param {import('xmlbuilder').XMLElement} element
+   * @returns {import('xmlbuilder').XMLElement}
+   */
+  buildNode(element) {
+    element = super.buildNode(element);
+    _.forEach(this._children, function (child) {
+      child.build(element);
+    });
+    return element;
   }
 }
 

--- a/src/test_group.js
+++ b/src/test_group.js
@@ -28,6 +28,15 @@ class TestGroup extends TestNode {
   }
 
   /**
+   * @returns {import('./test_case').TestCase}
+   */
+  testCase() {
+    var testCase = this._factory.newTestCase();
+    this._children.push(testCase);
+    return testCase;
+  }
+
+  /**
    * @returns {number}
    */
   getTestCaseCount() {
@@ -71,15 +80,6 @@ class TestGroup extends TestNode {
   _sumTestCaseCounts(counterFunction) {
     var counts = _.map(this._children, counterFunction);
     return _.sum(counts);
-  }
-
-  /**
-   * @returns {import('./test_case').TestCase}
-   */
-  testCase() {
-    var testCase = this._factory.newTestCase();
-    this._children.push(testCase);
-    return testCase;
   }
 
   /**

--- a/src/test_group.js
+++ b/src/test_group.js
@@ -61,7 +61,6 @@ class TestGroup extends TestNode {
    */
   _sumTestCaseCounts(counterFunction) {
     var counts = _.map(this._children, counterFunction);
-    // console.log('[debug]', counts, this._children);
     return _.sum(counts);
   }
 

--- a/src/test_group.js
+++ b/src/test_group.js
@@ -83,7 +83,7 @@ class TestGroup extends TestNode {
   }
 
   /**
-   * @param {import('xmlbuilder').XMLElement} parentElement
+   * @param {import('xmlbuilder').XMLElement} [parentElement]
    * @returns {import('xmlbuilder').XMLElement}
    */
   build(parentElement) {

--- a/src/test_group.js
+++ b/src/test_group.js
@@ -1,0 +1,90 @@
+// @ts-check
+var _ = require('lodash');
+var formatDate = require('date-format').asString;
+var { TestNode } = require('./test_node');
+
+class TestGroup extends TestNode {
+  /**
+   * @param {string|Date} timestamp
+   * @returns {TestGroup}
+   * @chainable
+   */
+  timestamp(timestamp) {
+    if (_.isDate(timestamp)) {
+      this._attributes.timestamp = formatDate('yyyy-MM-ddThh:mm:ss', timestamp);
+    } else {
+      this._attributes.timestamp = timestamp;
+    }
+    return this;
+  }
+
+  /**
+   * @returns {number}
+   */
+  getTestCaseCount() {
+    return this._sumTestCaseCounts(function (testCase) {
+      return testCase.getTestCaseCount();
+    });
+  }
+
+  /**
+   * @returns {number}
+   */
+  getFailureCount() {
+    return this._sumTestCaseCounts(function (testCase) {
+      return testCase.getFailureCount();
+    });
+  }
+
+  /**
+   * @returns {number}
+   */
+  getErrorCount() {
+    return this._sumTestCaseCounts(function (testCase) {
+      return testCase.getErrorCount();
+    });
+  }
+
+  /**
+   * @returns {number}
+   */
+  getSkippedCount() {
+    return this._sumTestCaseCounts(function (testCase) {
+      return testCase.getSkippedCount();
+    });
+  }
+
+  /**
+   * @protected
+   * @param {Function} counterFunction
+   * @returns
+   */
+  _sumTestCaseCounts(counterFunction) {
+    var counts = _.map(this._children, counterFunction);
+    // console.log('[debug]', counts, this._children);
+    return _.sum(counts);
+  }
+
+  /**
+   * @returns {import('./test_case').TestCase}
+   */
+  testCase() {
+    var testCase = this._factory.newTestCase();
+    this._children.push(testCase);
+    return testCase;
+  }
+
+  /**
+   * @param {import('xmlbuilder').XMLElement} parentElement
+   * @returns {import('xmlbuilder').XMLElement}
+   */
+  build(parentElement) {
+    this._attributes.tests = this.getTestCaseCount();
+    this._attributes.failures = this.getFailureCount();
+    this._attributes.errors = this.getErrorCount();
+    this._attributes.skipped = this.getSkippedCount();
+    return super.build(parentElement);
+  }
+}
+
+module.exports = { TestGroup: TestGroup };

--- a/src/test_node.js
+++ b/src/test_node.js
@@ -49,7 +49,7 @@ class TestNode {
    * @param {import('xmlbuilder').XMLElement} parentElement
    * @returns {import('xmlbuilder').XMLElement}
    */
-  createNode(parentElement) {
+  createElement(parentElement) {
     return parentElement.ele(this._elementName, this._attributes);
   }
 
@@ -103,7 +103,7 @@ class TestNode {
    * @param {import('xmlbuilder').XMLElement} parentElement
    */
   build(parentElement) {
-    return this.buildNode(this.createNode(parentElement));
+    return this.buildNode(this.createElement(parentElement));
   }
 }
 

--- a/src/test_node.js
+++ b/src/test_node.js
@@ -1,0 +1,124 @@
+// @ts-check
+var _ = require('lodash');
+
+class TestNode {
+  /**
+   * @param {import('./factory').Factory} factory
+   * @param {string} nodeName
+   */
+  constructor(factory, nodeName) {
+    this._factory = factory;
+    this._nodeName = nodeName;
+    this._attributes = {};
+    this._properties = [];
+    this._children = [];
+  }
+
+  /**
+   * @param {string} name
+   * @param {string} value
+   * @returns {TestNode}
+   * @chainable
+   */
+  property(name, value) {
+    this._properties.push({ name: name, value: value });
+    return this;
+  }
+
+  /**
+   * @param {string} className
+   * @returns {TestNode}
+   * @chainable
+   */
+  className(className) {
+    this._attributes.classname = className;
+    return this;
+  }
+
+  /**
+   * @param {string} name
+   * @returns {TestNode}
+   * @chainable
+   */
+  name(name) {
+    this._attributes.name = name;
+    return this;
+  }
+
+  /**
+   * @param {string} timeInSeconds
+   * @returns {TestNode}
+   * @chainable
+   */
+  time(timeInSeconds) {
+    this._attributes.time = timeInSeconds;
+    return this;
+  }
+
+  /**
+   * @protected
+   * @param {import('xmlbuilder').XMLElement} parentElement
+   * @returns {import('xmlbuilder').XMLElement}
+   */
+  createNode(parentElement) {
+    return parentElement.ele(this._nodeName, this._attributes);
+  }
+
+  /**
+   * @protected
+   * @param {import('xmlbuilder').XMLElement} element
+   * @returns {import('xmlbuilder').XMLElement}
+   */
+  buildNode(element) {
+    if (this._properties.length) {
+      var propertiesElement = element.ele('properties');
+      _.forEach(this._properties, function (property) {
+        propertiesElement.ele('property', {
+          name: property.name,
+          value: property.value,
+        });
+      });
+    }
+    _.forEach(this._children, function (child) {
+      child.build(element);
+    });
+    return element;
+  }
+
+  /**
+   * @returns {number}
+   */
+  getTestCaseCount() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * @returns {number}
+   */
+  getFailureCount() {
+    return 0;
+  }
+
+  /**
+   * @returns {number}
+   */
+  getErrorCount() {
+    return 0;
+  }
+
+  /**
+   * @returns {number}
+   */
+  getSkippedCount() {
+    return 0;
+  }
+
+  /**
+   * @param {import('xmlbuilder').XMLElement} parentElement
+   */
+  build(parentElement) {
+    return this.buildNode(this.createNode(parentElement));
+  }
+}
+
+module.exports = { TestNode: TestNode };

--- a/src/test_node.js
+++ b/src/test_node.js
@@ -96,21 +96,21 @@ class TestNode {
    * @returns {number}
    */
   getFailureCount() {
-    return 0;
+    throw new Error('Not implemented');
   }
 
   /**
    * @returns {number}
    */
   getErrorCount() {
-    return 0;
+    throw new Error('Not implemented');
   }
 
   /**
    * @returns {number}
    */
   getSkippedCount() {
-    return 0;
+    throw new Error('Not implemented');
   }
 
   /**

--- a/src/test_node.js
+++ b/src/test_node.js
@@ -1,5 +1,6 @@
 // @ts-check
 var _ = require('lodash');
+var xmlBuilder = require('xmlbuilder');
 
 class TestNode {
   /**
@@ -46,11 +47,26 @@ class TestNode {
 
   /**
    * @protected
-   * @param {import('xmlbuilder').XMLElement} parentElement
+   * @param {import('xmlbuilder').XMLElement} [parentElement]
    * @returns {import('xmlbuilder').XMLElement}
    */
   createElement(parentElement) {
-    return parentElement.ele(this._elementName, this._attributes);
+    if (parentElement) {
+      return parentElement.ele(this._elementName, this._attributes);
+    }
+    return this.createRootElement();
+  }
+
+  /**
+   * @private
+   * @returns {import('xmlbuilder').XMLElement}
+   */
+  createRootElement() {
+    const element = xmlBuilder.create(this._elementName, { encoding: 'UTF-8', invalidCharReplacement: '' });
+    Object.keys(this._attributes).forEach((key) => {
+      element.att(key, this._attributes[key]);
+    });
+    return element;
   }
 
   /**
@@ -100,7 +116,7 @@ class TestNode {
   }
 
   /**
-   * @param {import('xmlbuilder').XMLElement} parentElement
+   * @param {import('xmlbuilder').XMLElement} [parentElement]
    */
   build(parentElement) {
     return this.buildNode(this.createElement(parentElement));

--- a/src/test_node.js
+++ b/src/test_node.js
@@ -25,16 +25,6 @@ class TestNode {
   }
 
   /**
-   * @param {string} className
-   * @returns {TestNode}
-   * @chainable
-   */
-  className(className) {
-    this._attributes.classname = className;
-    return this;
-  }
-
-  /**
    * @param {string} name
    * @returns {TestNode}
    * @chainable

--- a/src/test_node.js
+++ b/src/test_node.js
@@ -46,6 +46,41 @@ class TestNode {
   }
 
   /**
+   * @returns {number}
+   */
+  getTestCaseCount() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * @returns {number}
+   */
+  getFailureCount() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * @returns {number}
+   */
+  getErrorCount() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * @returns {number}
+   */
+  getSkippedCount() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * @param {import('xmlbuilder').XMLElement} [parentElement]
+   */
+  build(parentElement) {
+    return this.buildNode(this.createElement(parentElement));
+  }
+
+  /**
    * @protected
    * @param {import('xmlbuilder').XMLElement} [parentElement]
    * @returns {import('xmlbuilder').XMLElement}
@@ -85,41 +120,6 @@ class TestNode {
       });
     }
     return element;
-  }
-
-  /**
-   * @returns {number}
-   */
-  getTestCaseCount() {
-    throw new Error('Not implemented');
-  }
-
-  /**
-   * @returns {number}
-   */
-  getFailureCount() {
-    throw new Error('Not implemented');
-  }
-
-  /**
-   * @returns {number}
-   */
-  getErrorCount() {
-    throw new Error('Not implemented');
-  }
-
-  /**
-   * @returns {number}
-   */
-  getSkippedCount() {
-    throw new Error('Not implemented');
-  }
-
-  /**
-   * @param {import('xmlbuilder').XMLElement} [parentElement]
-   */
-  build(parentElement) {
-    return this.buildNode(this.createElement(parentElement));
   }
 }
 

--- a/src/test_node.js
+++ b/src/test_node.js
@@ -11,7 +11,6 @@ class TestNode {
     this._nodeName = nodeName;
     this._attributes = {};
     this._properties = [];
-    this._children = [];
   }
 
   /**
@@ -79,9 +78,6 @@ class TestNode {
         });
       });
     }
-    _.forEach(this._children, function (child) {
-      child.build(element);
-    });
     return element;
   }
 

--- a/src/test_node.js
+++ b/src/test_node.js
@@ -4,11 +4,11 @@ var _ = require('lodash');
 class TestNode {
   /**
    * @param {import('./factory').Factory} factory
-   * @param {string} nodeName
+   * @param {string} elementName
    */
-  constructor(factory, nodeName) {
+  constructor(factory, elementName) {
     this._factory = factory;
-    this._nodeName = nodeName;
+    this._elementName = elementName;
     this._attributes = {};
     this._properties = [];
   }
@@ -50,7 +50,7 @@ class TestNode {
    * @returns {import('xmlbuilder').XMLElement}
    */
   createNode(parentElement) {
-    return parentElement.ele(this._nodeName, this._attributes);
+    return parentElement.ele(this._elementName, this._attributes);
   }
 
   /**

--- a/src/test_suite.js
+++ b/src/test_suite.js
@@ -1,128 +1,14 @@
 // @ts-check
 var _ = require('lodash');
-var formatDate = require('date-format').asString;
+var { TestGroup } = require('./test_group');
 
-class TestSuite {
+class TestSuite extends TestGroup {
   /**
-   * @param {import('./factory')} factory
+   * @param {import('./factory').Factory} factory
    */
   constructor(factory) {
-    this._factory = factory;
-    this._attributes = {};
-    this._testCases = [];
-    this._properties = [];
-  }
-
-  /**
-   * @param {string} name
-   * @chainable
-   */
-  name(name) {
-    this._attributes.name = name;
-    return this;
-  }
-
-  /**
-   * @param {number} timeInSeconds
-   * @chainable
-   */
-  time(timeInSeconds) {
-    this._attributes.time = timeInSeconds;
-    return this;
-  }
-
-  /**
-   * @param {Date|string} timestamp
-   * @chainable
-   */
-  timestamp(timestamp) {
-    if (_.isDate(timestamp)) {
-      this._attributes.timestamp = formatDate('yyyy-MM-ddThh:mm:ss', timestamp);
-    } else {
-      this._attributes.timestamp = timestamp;
-    }
-    return this;
-  }
-
-  /**
-   * @param {string} name
-   * @param {string} value
-   * @chainable
-   */
-  property(name, value) {
-    this._properties.push({ name: name, value: value });
-    return this;
-  }
-
-  /**
-   * @returns {import('./test_case')}
-   */
-  testCase() {
-    var testCase = this._factory.newTestCase();
-    this._testCases.push(testCase);
-    return testCase;
-  }
-
-  /**
-   * @returns {number}
-   */
-  getFailureCount() {
-    return this._sumTestCaseCounts(function (testCase) {
-      return testCase.getFailureCount();
-    });
-  }
-
-  /**
-   * @returns {number}
-   */
-  getErrorCount() {
-    return this._sumTestCaseCounts(function (testCase) {
-      return testCase.getErrorCount();
-    });
-  }
-
-  /**
-   * @returns {number}
-   */
-  getSkippedCount() {
-    return this._sumTestCaseCounts(function (testCase) {
-      return testCase.getSkippedCount();
-    });
-  }
-
-  /**
-   * @param {(testCase: import('./test_case')) => number} counterFunction
-   * @returns {number}
-   */
-  _sumTestCaseCounts(counterFunction) {
-    var counts = _.map(this._testCases, counterFunction);
-    return _.sum(counts);
-  }
-
-  /**
-   * @param {import('xmlbuilder').XMLElement} parentElement
-   */
-  build(parentElement) {
-    this._attributes.tests = this._testCases.length;
-    this._attributes.failures = this.getFailureCount();
-    this._attributes.errors = this.getErrorCount();
-    this._attributes.skipped = this.getSkippedCount();
-    var suiteElement = parentElement.ele('testsuite', this._attributes);
-
-    if (this._properties.length) {
-      var propertiesElement = suiteElement.ele('properties');
-      _.forEach(this._properties, function (property) {
-        propertiesElement.ele('property', {
-          name: property.name,
-          value: property.value,
-        });
-      });
-    }
-
-    _.forEach(this._testCases, function (testCase) {
-      testCase.build(suiteElement);
-    });
+    super(factory, 'testsuite');
   }
 }
 
-module.exports = TestSuite;
+module.exports = { TestSuite: TestSuite };

--- a/src/test_suite.js
+++ b/src/test_suite.js
@@ -1,86 +1,128 @@
+// @ts-check
 var _ = require('lodash');
 var formatDate = require('date-format').asString;
 
-function TestSuite(factory) {
-  this._factory = factory;
-  this._attributes = {};
-  this._testCases = [];
-  this._properties = [];
-}
-
-TestSuite.prototype.name = function (name) {
-  this._attributes.name = name;
-  return this;
-};
-
-TestSuite.prototype.time = function (timeInSeconds) {
-  this._attributes.time = timeInSeconds;
-  return this;
-};
-
-TestSuite.prototype.timestamp = function (timestamp) {
-  if (_.isDate(timestamp)) {
-    this._attributes.timestamp = formatDate('yyyy-MM-ddThh:mm:ss', timestamp);
-  } else {
-    this._attributes.timestamp = timestamp;
+class TestSuite {
+  /**
+   * @param {import('./factory')} factory
+   */
+  constructor(factory) {
+    this._factory = factory;
+    this._attributes = {};
+    this._testCases = [];
+    this._properties = [];
   }
-  return this;
-};
 
-TestSuite.prototype.property = function (name, value) {
-  this._properties.push({ name: name, value: value });
-  return this;
-};
+  /**
+   * @param {string} name
+   * @chainable
+   */
+  name(name) {
+    this._attributes.name = name;
+    return this;
+  }
 
-TestSuite.prototype.testCase = function () {
-  var testCase = this._factory.newTestCase();
-  this._testCases.push(testCase);
-  return testCase;
-};
+  /**
+   * @param {number} timeInSeconds
+   * @chainable
+   */
+  time(timeInSeconds) {
+    this._attributes.time = timeInSeconds;
+    return this;
+  }
 
-TestSuite.prototype.getFailureCount = function () {
-  return this._sumTestCaseCounts(function (testCase) {
-    return testCase.getFailureCount();
-  });
-};
+  /**
+   * @param {Date|string} timestamp
+   * @chainable
+   */
+  timestamp(timestamp) {
+    if (_.isDate(timestamp)) {
+      this._attributes.timestamp = formatDate('yyyy-MM-ddThh:mm:ss', timestamp);
+    } else {
+      this._attributes.timestamp = timestamp;
+    }
+    return this;
+  }
 
-TestSuite.prototype.getErrorCount = function () {
-  return this._sumTestCaseCounts(function (testCase) {
-    return testCase.getErrorCount();
-  });
-};
+  /**
+   * @param {string} name
+   * @param {string} value
+   * @chainable
+   */
+  property(name, value) {
+    this._properties.push({ name: name, value: value });
+    return this;
+  }
 
-TestSuite.prototype.getSkippedCount = function () {
-  return this._sumTestCaseCounts(function (testCase) {
-    return testCase.getSkippedCount();
-  });
-};
+  /**
+   * @returns {import('./test_case')}
+   */
+  testCase() {
+    var testCase = this._factory.newTestCase();
+    this._testCases.push(testCase);
+    return testCase;
+  }
 
-TestSuite.prototype._sumTestCaseCounts = function (counterFunction) {
-  var counts = _.map(this._testCases, counterFunction);
-  return _.sum(counts);
-};
-
-TestSuite.prototype.build = function (parentElement) {
-  this._attributes.tests = this._testCases.length;
-  this._attributes.failures = this.getFailureCount();
-  this._attributes.errors = this.getErrorCount();
-  this._attributes.skipped = this.getSkippedCount();
-  var suiteElement = parentElement.ele('testsuite', this._attributes);
-
-  if (this._properties.length) {
-    var propertiesElement = suiteElement.ele('properties');
-    _.forEach(this._properties, function (property) {
-      propertiesElement.ele('property', {
-        name: property.name,
-        value: property.value,
-      });
+  /**
+   * @returns {number}
+   */
+  getFailureCount() {
+    return this._sumTestCaseCounts(function (testCase) {
+      return testCase.getFailureCount();
     });
   }
 
-  _.forEach(this._testCases, function (testCase) {
-    testCase.build(suiteElement);
-  });
-};
+  /**
+   * @returns {number}
+   */
+  getErrorCount() {
+    return this._sumTestCaseCounts(function (testCase) {
+      return testCase.getErrorCount();
+    });
+  }
+
+  /**
+   * @returns {number}
+   */
+  getSkippedCount() {
+    return this._sumTestCaseCounts(function (testCase) {
+      return testCase.getSkippedCount();
+    });
+  }
+
+  /**
+   * @param {(testCase: import('./test_case')) => number} counterFunction
+   * @returns {number}
+   */
+  _sumTestCaseCounts(counterFunction) {
+    var counts = _.map(this._testCases, counterFunction);
+    return _.sum(counts);
+  }
+
+  /**
+   * @param {import('xmlbuilder').XMLElement} parentElement
+   */
+  build(parentElement) {
+    this._attributes.tests = this._testCases.length;
+    this._attributes.failures = this.getFailureCount();
+    this._attributes.errors = this.getErrorCount();
+    this._attributes.skipped = this.getSkippedCount();
+    var suiteElement = parentElement.ele('testsuite', this._attributes);
+
+    if (this._properties.length) {
+      var propertiesElement = suiteElement.ele('properties');
+      _.forEach(this._properties, function (property) {
+        propertiesElement.ele('property', {
+          name: property.name,
+          value: property.value,
+        });
+      });
+    }
+
+    _.forEach(this._testCases, function (testCase) {
+      testCase.build(suiteElement);
+    });
+  }
+}
 
 module.exports = TestSuite;

--- a/src/test_suites.js
+++ b/src/test_suites.js
@@ -23,7 +23,7 @@ class TestSuites extends TestGroup {
    * @protected
    * @returns {import('xmlbuilder').XMLElement}
    */
-  createNode() {
+  createElement() {
     const node = xmlBuilder.create('testsuites', { encoding: 'UTF-8', invalidCharReplacement: '' });
     Object.keys(this._attributes).forEach((key) => {
       node.att(key, this._attributes[key]);

--- a/src/test_suites.js
+++ b/src/test_suites.js
@@ -1,0 +1,35 @@
+// @ts-check
+var xmlBuilder = require('xmlbuilder');
+var { TestGroup } = require('./test_group');
+
+class TestSuites extends TestGroup {
+  /**
+   * @param {import('./factory').Factory} factory
+   */
+  constructor(factory) {
+    super(factory, 'testsuites');
+  }
+
+  /**
+   * @returns {import('./test_suite').TestSuite}
+   */
+  testSuite() {
+    var suite = this._factory.newTestSuite();
+    this._children.push(suite);
+    return suite;
+  }
+
+  /**
+   * @protected
+   * @returns {import('xmlbuilder').XMLElement}
+   */
+  createNode() {
+    const node = xmlBuilder.create('testsuites', { encoding: 'UTF-8', invalidCharReplacement: '' });
+    Object.keys(this._attributes).forEach((key) => {
+      node.att(key, this._attributes[key]);
+    });
+    return node;
+  }
+}
+
+module.exports = { TestSuites: TestSuites };

--- a/src/test_suites.js
+++ b/src/test_suites.js
@@ -1,5 +1,4 @@
 // @ts-check
-var xmlBuilder = require('xmlbuilder');
 var { TestGroup } = require('./test_group');
 
 class TestSuites extends TestGroup {
@@ -17,18 +16,6 @@ class TestSuites extends TestGroup {
     var suite = this._factory.newTestSuite();
     this._children.push(suite);
     return suite;
-  }
-
-  /**
-   * @protected
-   * @returns {import('xmlbuilder').XMLElement}
-   */
-  createElement() {
-    const node = xmlBuilder.create('testsuites', { encoding: 'UTF-8', invalidCharReplacement: '' });
-    Object.keys(this._attributes).forEach((key) => {
-      node.att(key, this._attributes[key]);
-    });
-    return node;
   }
 }
 


### PR DESCRIPTION
Adding the JSDoc comments should create support for not needing individual types, at minimum this and the `// @ts-check` comment gives some extra typechecking without upgrading everything to typescript

Fixes #8 