### PR TITLE
Drop support for Node.js 14 and older

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Please refer to the [e2e_spec.coffee](spec/e2e_spec.coffee) for more details on 
 
 ## Changelog
 
+### 4.0.0
+
+-   Dropped support for node.js 14, 12, 10 and 8.
+
 ### 3.2.1
 
 -   Update documentation.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/davidparsson/junit-report-builder",
   "engines": {
-    "node": ">=8"
+    "node": ">=16"
   },
   "devDependencies": {
     "grunt": "^1.6.1",


### PR DESCRIPTION
They are very old, and probably hazardous to use.