### PR TITLE
Add multilineProperty method to test_node

### DIFF
--- a/spec/e2e.spec.ts
+++ b/spec/e2e.spec.ts
@@ -29,7 +29,7 @@ describe('JUnit Report builder', () => {
       .name('Third test')
       .file('./path-to/the-test-file.coffee')
       .property('property name', 'property value')
-      .textContentProperty('property name 2', 'property value 2');
+      .multilineProperty('property name 2', 'property value 2');
 
     const suite2 = builder.testSuite().name('second.Suite');
     suite2.testCase().failure('Failure message');

--- a/spec/e2e.spec.ts
+++ b/spec/e2e.spec.ts
@@ -28,7 +28,8 @@ describe('JUnit Report builder', () => {
       .className('suite1.test.Class2')
       .name('Third test')
       .file('./path-to/the-test-file.coffee')
-      .property('property name', 'property value');
+      .property('property name', 'property value')
+      .property('property name 2', 'property value 2', true);
 
     const suite2 = builder.testSuite().name('second.Suite');
     suite2.testCase().failure('Failure message');

--- a/spec/e2e.spec.ts
+++ b/spec/e2e.spec.ts
@@ -29,7 +29,7 @@ describe('JUnit Report builder', () => {
       .name('Third test')
       .file('./path-to/the-test-file.coffee')
       .property('property name', 'property value')
-      .property('property name 2', 'property value 2', true);
+      .textContentProperty('property name 2', 'property value 2');
 
     const suite2 = builder.testSuite().name('second.Suite');
     suite2.testCase().failure('Failure message');

--- a/spec/expected_report.xml
+++ b/spec/expected_report.xml
@@ -6,6 +6,7 @@
     <testcase classname="suite1.test.Class2" name="Third test" file="./path-to/the-test-file.coffee">
       <properties>
         <property name="property name" value="property value"/>
+        <property name="property name 2">property value 2</property>
       </properties>
     </testcase>
   </testsuite>

--- a/spec/test_case.spec.ts
+++ b/spec/test_case.spec.ts
@@ -127,6 +127,20 @@ describe('Test Case builder', () => {
     });
   });
 
+  it('should add the provided property with textContent as elements with textContent', () => {
+    testCase.property('property name', 'property value', true);
+
+    testCase.build(parentElement);
+
+    expect(propertiesElement.ele).toHaveBeenCalledWith(
+      'property',
+      {
+        name: 'property name',
+      },
+      'property value',
+    );
+  });
+
   it('should add a failure node when test failed', () => {
     testCase.failure();
 

--- a/spec/test_case.spec.ts
+++ b/spec/test_case.spec.ts
@@ -128,7 +128,7 @@ describe('Test Case builder', () => {
   });
 
   it('should add the provided property with textContent as elements with textContent', () => {
-    testCase.textContentProperty('property name', 'property value');
+    testCase.multilineProperty('property name', 'property value');
 
     testCase.build(parentElement);
 

--- a/spec/test_case.spec.ts
+++ b/spec/test_case.spec.ts
@@ -128,7 +128,7 @@ describe('Test Case builder', () => {
   });
 
   it('should add the provided property with textContent as elements with textContent', () => {
-    testCase.property('property name', 'property value', true);
+    testCase.textContentProperty('property name', 'property value');
 
     testCase.build(parentElement);
 

--- a/spec/test_suite.spec.ts
+++ b/spec/test_suite.spec.ts
@@ -132,6 +132,20 @@ describe('Test Suite builder', () => {
     });
   });
 
+  it('should add the provided property with textContent as element with textContent', () => {
+    testSuite.property('property name', 'property value', true);
+
+    testSuite.build(parentElement);
+
+    expect(propertiesElement.ele).toHaveBeenCalledWith(
+      'property',
+      {
+        name: 'property name',
+      },
+      'property value',
+    );
+  });
+
   it('should add all the provided properties as elements', () => {
     testSuite.property('name 1', 'value 1');
     testSuite.property('name 2', 'value 2');

--- a/spec/test_suite.spec.ts
+++ b/spec/test_suite.spec.ts
@@ -133,7 +133,7 @@ describe('Test Suite builder', () => {
   });
 
   it('should add the provided property with textContent as element with textContent', () => {
-    testSuite.textContentProperty('property name', 'property value');
+    testSuite.multilineProperty('property name', 'property value');
 
     testSuite.build(parentElement);
 

--- a/spec/test_suite.spec.ts
+++ b/spec/test_suite.spec.ts
@@ -133,7 +133,7 @@ describe('Test Suite builder', () => {
   });
 
   it('should add the provided property with textContent as element with textContent', () => {
-    testSuite.property('property name', 'property value', true);
+    testSuite.textContentProperty('property name', 'property value');
 
     testSuite.build(parentElement);
 

--- a/src/test_node.ts
+++ b/src/test_node.ts
@@ -30,8 +30,18 @@ export abstract class TestNode {
    * @param value
    * @returns this
    */
-  property(name: string, value: string, isPropertyWithTextContent: boolean = false): this {
-    this._properties.push({ name: name, value: value, isPropertyWithTextContent: isPropertyWithTextContent });
+  property(name: string, value: string): this {
+    this._properties.push({ name: name, value: value, isPropertyWithTextContent: false });
+    return this;
+  }
+
+  /**
+   * @param name
+   * @param value
+   * @returns this
+   */
+  textContentProperty(name: string, value: string): this {
+    this._properties.push({ name: name, value: value, isPropertyWithTextContent: true });
     return this;
   }
 

--- a/src/test_node.ts
+++ b/src/test_node.ts
@@ -1,10 +1,20 @@
 import _ from 'lodash';
 import xmlBuilder, { type XMLElement } from 'xmlbuilder';
 
+/** Helper interface to describe one property */
+interface Property {
+  /** name of the property */
+  name: string;
+  /** value of the property */
+  value: string;
+  /** if true the property will be serialized as node with textcontent */
+  isPropertyWithTextContent: boolean;
+}
+
 export abstract class TestNode {
   private _elementName: string;
   protected _attributes: any;
-  private _properties: any[];
+  private _properties: Property[];
 
   /**
    * @param elementName - the name of the XML element
@@ -20,8 +30,8 @@ export abstract class TestNode {
    * @param value
    * @returns this
    */
-  property(name: string, value: string): this {
-    this._properties.push({ name: name, value: value });
+  property(name: string, value: string, isPropertyWithTextContent: boolean = false): this {
+    this._properties.push({ name: name, value: value, isPropertyWithTextContent: isPropertyWithTextContent });
     return this;
   }
 
@@ -122,11 +132,12 @@ export abstract class TestNode {
   protected buildNode(element: XMLElement): XMLElement {
     if (this._properties.length) {
       var propertiesElement = element.ele('properties');
-      _.forEach(this._properties, (property: any) => {
-        propertiesElement.ele('property', {
-          name: property.name,
-          value: property.value,
-        });
+      _.forEach(this._properties, (property: Property) => {
+        if (property.isPropertyWithTextContent) {
+          propertiesElement.ele('property', { name: property.name }, property.value);
+        } else {
+          propertiesElement.ele('property', { name: property.name, value: property.value });
+        }
       });
     }
     return element;

--- a/src/test_node.ts
+++ b/src/test_node.ts
@@ -40,7 +40,7 @@ export abstract class TestNode {
    * @param value
    * @returns this
    */
-  textContentProperty(name: string, value: string): this {
+  multilineProperty(name: string, value: string): this {
     this._properties.push({ name: name, value: value, isPropertyWithTextContent: true });
     return this;
   }


### PR DESCRIPTION
Some tools allow the property to have a textContent and not use the value attribute. 

See https://github.com/testmoapp/junitxml?tab=readme-ov-file#properties-for-suites-and-cases for examples.