### PR TITLE
replace `lodash` deps with native JS functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "5.1.2",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.18.1",
         "make-dir": "^3.1.0",
         "xmlbuilder": "^15.1.1"
       },
@@ -18,7 +17,6 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-typescript": "^11.1.6",
         "@types/jest": "^29.5.12",
-        "@types/lodash": "^4.17.0",
         "@types/node": "^20.12.7",
         "@types/rimraf": "^4.0.5",
         "husky": "^9.1.4",
@@ -3611,12 +3609,6 @@
         "pretty-format": "^29.0.0"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
-      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
-      "dev": true
-    },
     "node_modules/@types/node": {
       "version": "20.12.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
@@ -7024,11 +7016,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
@@ -11684,12 +11671,6 @@
         "pretty-format": "^29.0.0"
       }
     },
-    "@types/lodash": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
-      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
-      "dev": true
-    },
     "@types/node": {
       "version": "20.12.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
@@ -14161,11 +14142,6 @@
       "requires": {
         "p-locate": "^4.1.0"
       }
-    },
-    "lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.capitalize": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/jest": "^29.5.12",
-    "@types/lodash": "^4.17.0",
     "@types/node": "^20.12.7",
     "@types/rimraf": "^4.0.5",
     "husky": "^9.1.4",
@@ -58,7 +57,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "lodash": "^4.18.1",
     "make-dir": "^3.1.0",
     "xmlbuilder": "^15.1.1"
   },

--- a/src/test_case.ts
+++ b/src/test_case.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { TestNode } from './test_node';
 import type { XMLElement } from 'xmlbuilder';
 

--- a/src/test_group.ts
+++ b/src/test_group.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { TestNode } from './test_node';
 import type { TestCase } from './test_case';
 import type { XMLElement } from 'xmlbuilder';
@@ -25,7 +24,7 @@ export abstract class TestGroup extends TestNode {
    * @returns this
    */
   timestamp(timestamp: string | Date): this {
-    if (_.isDate(timestamp)) {
+    if (isDate(timestamp)) {
       this._attributes.timestamp = this.formatDate(timestamp);
     } else {
       this._attributes.timestamp = timestamp;
@@ -105,9 +104,20 @@ export abstract class TestGroup extends TestNode {
    */
   protected buildNode(element: XMLElement) {
     element = super.buildNode(element);
-    _.forEach(this._children, (child) => {
+    for (const child of this._children) {
       child.build(element);
-    });
+    }
     return element;
   }
+}
+
+//#region internal helper functions
+
+/**
+ * Check if a value is a Date object.
+ *
+ * @see https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_isdate
+ */
+function isDate(value: unknown): value is Date {
+  return Object.prototype.toString.call(value) === '[object Date]';
 }

--- a/src/test_node.ts
+++ b/src/test_node.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import xmlBuilder, { type XMLElement } from 'xmlbuilder';
 
 /** Helper interface to describe one property */
@@ -142,13 +141,13 @@ export abstract class TestNode {
   protected buildNode(element: XMLElement): XMLElement {
     if (this._properties.length) {
       var propertiesElement = element.ele('properties');
-      _.forEach(this._properties, (property: Property) => {
+      for (const property of this._properties) {
         if (property.isPropertyWithTextContent) {
           propertiesElement.ele('property', { name: property.name }, property.value);
         } else {
           propertiesElement.ele('property', { name: property.name, value: property.value });
         }
-      });
+      }
     }
     return element;
   }


### PR DESCRIPTION
Removing `lodash` in this package's dependencies list might bring us (end-user apps) simpler dependency graphs and resilience against supply-chain attacks.

I wish this change will be helpful.